### PR TITLE
Set the app icon to display in the notification when app is minimized #114 

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -236,6 +236,7 @@ const sendAppHideNotification = () => {
   // Object
   notifier.notify({
     title: 'CERN Phone App',
+    icon: path.join(__dirname, '../assets/icon.png'),
     message: 'The app has been minimized to tray.'
   });
 };


### PR DESCRIPTION
We still have a small terminal Icon but it's not the principal one.

[It's possible to change this](https://stackoverflow.com/a/50831884), but maybe it's not needed because we can easily understand from which application we are receiving this notification.

![Screen Shot 2019-09-19 at 10 56 40](https://user-images.githubusercontent.com/31002428/65229210-2f1b1b80-dacc-11e9-98a0-41bc72c148b8.png)
