### PR TITLE
Display loading icon when answering a call until accept event is received

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,6 @@ import NotConnectedScreenContainer from 'calls/screens/CallsScreen/NotConnectedS
 import * as routes from 'routes';
 import * as loginRoutes from 'auth/routes';
 import { registerRoute } from 'calls/routes';
-import { logMessage } from 'common/utils/logs';
 
 const NoMatch = ({ location }) => (
   <div>

--- a/src/calls/components/call_modals/IncomingCallModal/IncomingCallModal.js
+++ b/src/calls/components/call_modals/IncomingCallModal/IncomingCallModal.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, useState } from 'react';
 import PropTypes from 'prop-types';
 import { translate } from 'react-i18next';
 import { Button, Header, Icon, Modal } from 'semantic-ui-react';
@@ -55,7 +55,7 @@ RejectButton.propTypes = { onClick: PropTypes.func };
  * @returns {*}
  * @constructor
  */
-function AnswerButton({ onClick }) {
+function AnswerButton({ onClick, loading }) {
   return (
     <Button
       positive
@@ -64,6 +64,7 @@ function AnswerButton({ onClick }) {
       labelPosition="right"
       content="Answer"
       className="AnswerCallButton"
+      loading={(!!loading)}
     />
   );
 }
@@ -78,6 +79,7 @@ function CallingModalContent({
   onClickHangupAndAnswer,
   onCall
 }) {
+  const [answerLoading, setAnswerLoading] = useState(0);
   return (
     <React.Fragment>
       <Modal.Header>Receiving an incoming call</Modal.Header>
@@ -92,7 +94,7 @@ function CallingModalContent({
       </Modal.Content>
       <Modal.Actions>
         <RejectButton onClick={onClickReject} />
-        {!onCall && <AnswerButton onClick={onClickAnswer} />}
+        {!onCall && <AnswerButton onClick={() => { onClickAnswer(); setAnswerLoading(1); }} loading={answerLoading} />}
         {onCall && <HangupAndPickupButton onClick={onClickHangupAndAnswer} />}
       </Modal.Actions>
     </React.Fragment>


### PR DESCRIPTION
Now we can know when the app is processing an answered call.
It's only UX changes. there is a loading icon instead of the regular "answer" text.

This pull request will also resolve #111 