### PR TITLE
170 Enable Copy and Paste in all Application

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -223,6 +223,18 @@ const menu = Menu.buildFromTemplate([
     ]
   },
   {
+    label: "Edit",
+    submenu: [
+        { label: "Undo", accelerator: "CmdOrCtrl+Z", selector: "undo:" },
+        { label: "Redo", accelerator: "Shift+CmdOrCtrl+Z", selector: "redo:" },
+        { type: "separator" },
+        { label: "Cut", accelerator: "CmdOrCtrl+X", selector: "cut:" },
+        { label: "Copy", accelerator: "CmdOrCtrl+C", selector: "copy:" },
+        { label: "Paste", accelerator: "CmdOrCtrl+V", selector: "paste:" },
+        { label: "Select All", accelerator: "CmdOrCtrl+A", selector: "selectAll:" }
+    ]
+  },
+  {
     label: 'View',
     submenu: [
       { role: 'reload' },


### PR DESCRIPTION
#170 

I add the compatibility with the shorcuts for edit the text. This implementation is compatible with multiple operative systems (Windows, Linux and Mac) because has been implemented using the Electron Configuration.

- Copy
- Paste
- Cut
- Undo
- Redo
- Select All