### PR TITLE
Can push a new release with -no-sandbox by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,30 @@ Run the following command on `webapp` folder (this one).
 xattr -cr .
 ```
 
+### Steps to generate the right AppImage
+
+We had some difficulties when we tried to install our AppImage in `Centos 7`.
+
+By default the application was launched in a sandbox, which was making it crash. This is a kernel level configuration.
+
+If you take a look at our `build` section in `package.json`, you will find this command : `afterAllArtifactBuild`
+
+This command is launched right after the entire packaging step. It will call a function (docker/configure_appimage.js).
+
+This function will generate a docker image (docker/dockerfile) if it doesn't exists yet.
+
+This Docker Image has an entrypoint on a bash file that will add `--no-sandbox` option to the AppImage.
+
+`A volume attached to ***dist/*** will be used to get and modify the AppImage.`
+
+Then, once the docker image generated, the same function will get the docker image ID and launch it.
+
+`It will use the latest file matching this : dist/cern-phone-app-*-x86-64-linux.AppImage`
+
+You will see some logs during the packaging step related to this part.
+
+Every steps related to this part are in `docker/`.
+
 ## React Docs
 
 This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+build
+dist
+coverage
+src
+static
+static-next
+assets
+assets-next
+modules
+private

--- a/docker/bash.sh
+++ b/docker/bash.sh
@@ -1,8 +1,8 @@
 cd /root/home
 wget "https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage"
 chmod +x appimagetool-x86_64.AppImage
-./cern-phone-app-$(ls cern-phone-app-*-x86_64-linux.AppImage | cut -d "-" -f 4)-x86_64-linux.AppImage --appimage-extract
+./cern-phone-app-$(ls -Art cern-phone-app-*-x86-64-linux.AppImage | tail -n 1 | cut -d "-" -f 4)-x86_64-linux.AppImage --appimage-extract
 sed -i -e 's|"$BIN"|"$BIN" --no-sandbox|g' squashfs-root/AppRun
 sed -i -e 's|^Icon=.*|Icon=cern-phone-app|g'  squashfs-root/cern-phone-app.desktop
 ./appimagetool-x86_64.AppImage squashfs-root/
-mv CERN_Phone_App-x86_64.AppImage cern-phone-app-$(ls cern-phone-app-*-x86_64-linux.AppImage | cut -d "-" -f 4)-x86_64-linux.AppImage
+mv CERN_Phone_App-x86_64.AppImage cern-phone-app-$(ls -Art cern-phone-app-*-x86-64-linux.AppImage | tail -n 1 | cut -d "-" -f 4)-x86_64-linux.AppImage

--- a/docker/bash.sh
+++ b/docker/bash.sh
@@ -1,0 +1,8 @@
+cd /root/home
+wget "https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage"
+chmod +x appimagetool-x86_64.AppImage
+./cern-phone-app-$(ls cern-phone-app-*-x86_64-linux.AppImage | cut -d "-" -f 4)-x86_64-linux.AppImage --appimage-extract
+sed -i -e 's|"$BIN"|"$BIN" --no-sandbox|g' squashfs-root/AppRun
+sed -i -e 's|^Icon=.*|Icon=cern-phone-app|g'  squashfs-root/cern-phone-app.desktop
+./appimagetool-x86_64.AppImage squashfs-root/
+mv CERN_Phone_App-x86_64.AppImage cern-phone-app-$(ls cern-phone-app-*-x86_64-linux.AppImage | cut -d "-" -f 4)-x86_64-linux.AppImage

--- a/docker/configure_appimage.js
+++ b/docker/configure_appimage.js
@@ -1,0 +1,9 @@
+const system = require("system-commands");
+
+exports.default = async function(context) {
+  console.log("Adding --no-sandox to AppImage");
+  system("docker build docker/");
+  system("docker run -v $(pwd)/dist/:/root/home/ --privileged $(docker images -a | awk '{ print $3}' | awk 'NR==2')");
+  console.log("Done.");
+  return [];
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.7'
+services:
+  script:
+    build:
+      context: .
+      #    volumes:
+      #- ./dist:/root/home

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:18.04
+RUN apt-get update -y
+RUN apt-get install -y file libglib2.0-dev wget fuse
+
+ADD ./bash.sh /root/bash.sh
+RUN chmod +x  /root/bash.sh
+
+WORKDIR /root
+RUN wget "https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage"
+RUN chmod +x appimagetool-x86_64.AppImage
+
+ENTRYPOINT /root/bash.sh

--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
           "**/*"
         ]
       }
-    ]
+    ],
+    "afterAllArtifactBuild": "docker/configure_appimage.js"
   }
 }


### PR DESCRIPTION
completely resolve #141
We have a dockerfile that will generate a simple ubuntu:18.04 with an entrypoint on a script that will get the packed linux app and process it so it will be launched by default using --no-sandbox

It will process the latest file matching this : "cern-phone-app-*-x86_64-linux.AppImage"