### PR TITLE
Fixed docker, Was crashing in some cases

### DIFF
--- a/docker/bash.sh
+++ b/docker/bash.sh
@@ -1,8 +1,12 @@
 cd /root/home
-wget "https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage"
+if [ ! -f "appimagetool-x86_64.AppImage" ]; then
+    wget "https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage" 
+fi
 chmod +x appimagetool-x86_64.AppImage
-./cern-phone-app-$(ls -Art cern-phone-app-*-x86-64-linux.AppImage | tail -n 1 | cut -d "-" -f 4)-x86_64-linux.AppImage --appimage-extract
+./cern-phone-app-$(ls -Art cern-phone-app-*-x86_64-linux.AppImage | tail -n 1 | cut -d "-" -f 4)-x86_64-linux.AppImage --appimage-extract
 sed -i -e 's|"$BIN"|"$BIN" --no-sandbox|g' squashfs-root/AppRun
 sed -i -e 's|^Icon=.*|Icon=cern-phone-app|g'  squashfs-root/cern-phone-app.desktop
 ./appimagetool-x86_64.AppImage squashfs-root/
-mv CERN_Phone_App-x86_64.AppImage cern-phone-app-$(ls -Art cern-phone-app-*-x86-64-linux.AppImage | tail -n 1 | cut -d "-" -f 4)-x86_64-linux.AppImage
+mv $(ls -Art cern-phone-app-*-x86_64-linux.AppImage | tail -n 1) cern-phone-app-$(ls -Art cern-phone-app-*-x86_64-linux.AppImage | tail -n 1 | cut -d "-" -f 4)-x86_64-linux-original.AppImage
+mv CERN_Phone_App-x86_64.AppImage cern-phone-app-$(ls -Art cern-phone-app-*-x86_64-linux-original.AppImage | tail -n 1 | cut -d "-" -f 4)-x86_64-linux.AppImage
+rm -rf squashfs-root

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "react-dev-utils": "^9.0.1",
     "react-test-renderer": "^16.3.2",
     "redux-mock-store": "^1.5.1",
+    "system-commands": "^1.1.7",
     "typescript": "^3.5.2"
   },
   "build": {


### PR DESCRIPTION
Now it download appimagetool only once,
the original `cern-phone-app-0.5.6-x86_64-linux.AppImage` is renamed as `cern-phone-app-0.5.6-x86_64-linux-original.AppImage`
The new "patched" version is name `cern-phone-app-0.5.6-x86_64-linux.AppImage`
And the bash script remove `squashfs-root/` folder.