### PR TITLE
110 Ringtone output can be selected without changing the call audio output

### DIFF
--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -17,7 +17,8 @@
   "devices": {
     "header": "Devices",
     "audioInputLabel": "Input",
-    "audioOutputLabel": "Output"
+    "audioOutputLabel": "Output",
+    "ringtoneOutputLabel": "Ringtone Output"
   },
   "appInfo": {
     "header": "App Info",

--- a/src/common/screens/MainPage/MainPage.js
+++ b/src/common/screens/MainPage/MainPage.js
@@ -4,7 +4,11 @@ import { NavLink, Redirect, Route } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { Icon, Menu, Segment, Sidebar } from 'semantic-ui-react';
 import DetectRTC from 'detectrtc';
-import { getUserDevices, changeAudioDestination } from 'settings/utils/devices';
+import {
+  getUserDevices,
+  changeAudioInputDestination,
+  changeRingToneDestination
+} from 'settings/utils/devices';
 
 import './MainPage.css';
 import * as routes from 'routes';
@@ -148,7 +152,9 @@ export class MainPage extends Component {
       if (deviceList[a].value === speaker) return true;
     }
     this.props.setSpeaker('default');
-    changeAudioDestination('default');
+    changeAudioInputDestination('default');
+    changeRingToneDestination('default');
+
     return false;
   }
 

--- a/src/settings/actions/devices.js
+++ b/src/settings/actions/devices.js
@@ -1,16 +1,17 @@
-export const SET_MICROPHONE = '@@settings/SET_MICROPHONE'
-export const SET_SPEAKER = '@@settings/SET_SPEAKER'
+export const SET_MICROPHONE = '@@settings/SET_MICROPHONE';
+export const SET_SPEAKER = '@@settings/SET_SPEAKER';
+export const SET_RINGTONE_SPEAKER = '@@settings/SET_RINGTONE_SPEAKER';
 
 /**
  * Action that handles the change of microphone
  * @param deviceId Webrtc ID of the device
  * @returns {{type: string, deviceId: *}} The new microphone ID
  */
-export function setMicrophone (deviceId) {
+export function setMicrophone(deviceId) {
   return {
     type: SET_MICROPHONE,
     deviceId
-  }
+  };
 }
 
 /**
@@ -18,9 +19,21 @@ export function setMicrophone (deviceId) {
  * @param deviceId WebRTC id of the device
  * @returns {{type: string, deviceId: *}} The new speakers ID
  */
-export function setSpeaker (deviceId) {
+export function setSpeaker(deviceId) {
   return {
     type: SET_SPEAKER,
     deviceId
-  }
+  };
+}
+
+/**
+ * Action that handles the change of output device for the ring tone
+ * @param deviceId WebRTC id of the device
+ * @returns {{type: string, deviceId: *}} The new speakers ID
+ */
+export function setSpeakerRingtone(deviceId) {
+  return {
+    type: SET_RINGTONE_SPEAKER,
+    deviceId
+  };
 }

--- a/src/settings/actions/devices.test.js
+++ b/src/settings/actions/devices.test.js
@@ -1,0 +1,27 @@
+import * as actions from './devices';
+
+describe('devices actions', () => {
+  it('creates an action on SET_MICROPHONE', () => {
+    const expectedAction = {
+      type: actions.SET_MICROPHONE,
+      deviceId: '1234'
+    };
+    expect(actions.setMicrophone('1234')).toEqual(expectedAction);
+  });
+
+  it('creates an action on SET_SPEAKER', () => {
+    const expectedAction = {
+      type: actions.SET_SPEAKER,
+      deviceId: '1234'
+    };
+    expect(actions.setSpeaker('1234')).toEqual(expectedAction);
+  });
+
+  it('creates an action on SET_RINGTONE_SPEAKER', () => {
+    const expectedAction = {
+      type: actions.SET_RINGTONE_SPEAKER,
+      deviceId: '1234'
+    };
+    expect(actions.setSpeakerRingtone('1234')).toEqual(expectedAction);
+  });
+});

--- a/src/settings/components/DeviceSettings/DeviceSettings.js
+++ b/src/settings/components/DeviceSettings/DeviceSettings.js
@@ -1,10 +1,11 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import { Button, Form, Header } from "semantic-ui-react";
-import { translate } from "react-i18next";
-import ErrorBoundary from "common/components/ErrorBoundary/ErrorBoundary";
-import MicrophoneFieldContainer from "settings/components/DeviceSettings/MicrophoneField/MicrophoneFieldContainer";
-import SpeakersFieldContainer from "settings/components/DeviceSettings/SpeakersField/SpeakersFieldContainer";
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Button, Form, Header } from 'semantic-ui-react';
+import { translate } from 'react-i18next';
+import ErrorBoundary from 'common/components/ErrorBoundary/ErrorBoundary';
+import MicrophoneFieldContainer from 'settings/components/DeviceSettings/MicrophoneField/MicrophoneFieldContainer';
+import SpeakersFieldContainer from 'settings/components/DeviceSettings/SpeakersField/SpeakersFieldContainer';
+import SpeakersRingtoneFieldContainer from 'settings/components/DeviceSettings/SpeakersRingtoneField/SpeakersRingtoneFieldContainer';
 
 export class DeviceSettings extends Component {
   static propTypes = {
@@ -12,15 +13,11 @@ export class DeviceSettings extends Component {
   };
 
   playSound = () => {
-    document
-      .getElementById("ringbackTone")
-      .play();
+    document.getElementById('ringbackTone').play();
   };
 
   stopSound = () => {
-    document
-      .getElementById("ringbackTone")
-      .pause();
+    document.getElementById('ringbackTone').pause();
   };
 
   render() {
@@ -29,17 +26,22 @@ export class DeviceSettings extends Component {
     return (
       <div>
         <ErrorBoundary>
-          <Header as={"h4"}>{t("devices.header")}</Header>
+          <Header as={'h4'}>{t('devices.header')}</Header>
           <Form>
             <MicrophoneFieldContainer
-              fieldLabel={t("devices.audioInputLabel")}
-              fieldId={"audioSource"}
-              fieldType={"audioinput"}
+              fieldLabel={t('devices.audioInputLabel')}
+              fieldId={'audioSource'}
+              fieldType={'audioinput'}
             />
             <SpeakersFieldContainer
-              fieldLabel={t("devices.audioOutputLabel")}
-              fieldId={"audioOutput"}
-              fieldType={"audiooutput"}
+              fieldLabel={t('devices.audioOutputLabel')}
+              fieldId={'audioOutput'}
+              fieldType={'audiooutput'}
+            />
+            <SpeakersRingtoneFieldContainer
+              fieldLabel={t('devices.ringtoneOutputLabel')}
+              fieldId={'ringtoneOutput'}
+              fieldType={'audiooutput'}
             />
             <Button onClick={this.playSound}>Play Test Sound</Button>
             <Button onClick={this.stopSound}>Stop Test Sound</Button>
@@ -50,4 +52,4 @@ export class DeviceSettings extends Component {
   }
 }
 
-export default translate("settings")(DeviceSettings);
+export default translate('settings')(DeviceSettings);

--- a/src/settings/components/DeviceSettings/SpeakersField/SpeakersField.js
+++ b/src/settings/components/DeviceSettings/SpeakersField/SpeakersField.js
@@ -1,10 +1,10 @@
-import PropTypes from "prop-types";
-import { changeAudioDestination } from "settings/utils/devices";
+import PropTypes from 'prop-types';
+import { changeAudioInputDestination } from 'settings/utils/devices';
 import {
   DeviceField,
   devicePropTypes
-} from "settings/components/DeviceSettings/DeviceField";
-import DetectRTC from "detectrtc";
+} from 'settings/components/DeviceSettings/DeviceField';
+import DetectRTC from 'detectrtc';
 
 /**
  * Displays a dropdown field with all the speakers available
@@ -24,7 +24,6 @@ export class SpeakersField extends DeviceField {
   };
 
   componentDidMount = () => {
-
     this.state.hasDevice = false;
     if (this.props && this.props.outputDevice) {
       this.state.device = this.props.outputDevice;
@@ -36,12 +35,12 @@ export class SpeakersField extends DeviceField {
         hasDevice: DetectRTC.hasSpeakers
       });
     });
-    changeAudioDestination(this.state.device);
+    changeAudioInputDestination(this.state.device);
   };
 
   selectDevice = value => {
     this.props.setSpeaker(value);
-    changeAudioDestination(value);
+    changeAudioInputDestination(value);
   };
 }
 

--- a/src/settings/components/DeviceSettings/SpeakersRingtoneField/SpeakersRingtoneField.js
+++ b/src/settings/components/DeviceSettings/SpeakersRingtoneField/SpeakersRingtoneField.js
@@ -1,0 +1,47 @@
+import PropTypes from 'prop-types';
+import { changeRingToneDestination } from 'settings/utils/devices';
+import {
+  DeviceField,
+  devicePropTypes
+} from 'settings/components/DeviceSettings/DeviceField';
+import DetectRTC from 'detectrtc';
+
+/**
+ * Displays a dropdown field with all the speakers available
+ * @param t
+ * @param outputDevice
+ * @param selectOutputDevice
+ * @param hasSpeakers
+ * @param devices
+ * @returns {*}
+ * @constructor
+ */
+export class SpeakersRingtoneField extends DeviceField {
+  static propTypes = {
+    ...devicePropTypes,
+    setSpeakerRingtone: PropTypes.func.isRequired,
+    outputDevice: PropTypes.string
+  };
+
+  componentDidMount = () => {
+    this.state.hasDevice = false;
+    if (this.props && this.props.outputDevice) {
+      this.state.device = this.props.outputDevice;
+    }
+
+    super.componentDidMount();
+    DetectRTC.load(() => {
+      this.setState({
+        hasDevice: DetectRTC.hasSpeakers
+      });
+    });
+    changeRingToneDestination(this.state.device);
+  };
+
+  selectDevice = value => {
+    this.props.setSpeakerRingtone(value);
+    changeRingToneDestination(value);
+  };
+}
+
+export default SpeakersRingtoneField;

--- a/src/settings/components/DeviceSettings/SpeakersRingtoneField/SpeakersRingtoneFieldContainer.js
+++ b/src/settings/components/DeviceSettings/SpeakersRingtoneField/SpeakersRingtoneFieldContainer.js
@@ -5,7 +5,9 @@ import { setSpeakerRingtone } from 'settings/actions/devices';
 
 function mapStateToProps({ settings }) {
   return {
-    outputDevice: settings.devices ? settings.devices.speaker : undefined
+    outputDevice: settings.devices
+      ? settings.devices.speakerRingtone
+      : undefined
   };
 }
 

--- a/src/settings/components/DeviceSettings/SpeakersRingtoneField/SpeakersRingtoneFieldContainer.js
+++ b/src/settings/components/DeviceSettings/SpeakersRingtoneField/SpeakersRingtoneFieldContainer.js
@@ -1,0 +1,24 @@
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import SpeakersRingtoneField from 'settings/components/DeviceSettings/SpeakersRingtoneField/SpeakersRingtoneField';
+import { setSpeakerRingtone } from 'settings/actions/devices';
+
+function mapStateToProps({ settings }) {
+  return {
+    outputDevice: settings.devices ? settings.devices.speaker : undefined
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(
+    {
+      setSpeakerRingtone
+    },
+    dispatch
+  );
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(SpeakersRingtoneField);

--- a/src/settings/reducers/devices.js
+++ b/src/settings/reducers/devices.js
@@ -1,8 +1,9 @@
-import * as devices from 'settings/actions/devices'
+import * as devices from 'settings/actions/devices';
 
 const initialState = {
   microphone: null,
-  speaker: null
+  speaker: null,
+  speakerRingtone: null
 };
 
 /**
@@ -10,7 +11,7 @@ const initialState = {
  *
  * @param state Current state of the application
  * @param action Action to be triggered
- * @returns {{microphone: null, speaker: null}}
+ * @returns {{microphone: null, speaker: null, speakerRingtone: null}}
  */
 export default (state = initialState, action) => {
   switch (action.type) {
@@ -24,7 +25,12 @@ export default (state = initialState, action) => {
         ...state,
         speaker: action.deviceId
       };
+    case devices.SET_RINGTONE_SPEAKER:
+      return {
+        ...state,
+        speakerRingtone: action.deviceId
+      };
     default:
-      return state
+      return state;
   }
-}
+};

--- a/src/settings/reducers/devices.test.js
+++ b/src/settings/reducers/devices.test.js
@@ -1,0 +1,50 @@
+import reducer from './devices';
+import * as actions from '../actions/devices';
+
+describe('devices reducer', () => {
+  const initialState = {
+    microphone: null,
+    speaker: null,
+    speakerRingtone: null
+  };
+
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('it handles SET_MICROPHONE', () => {
+    expect(
+      reducer(undefined, {
+        type: actions.SET_MICROPHONE,
+        deviceId: '1234'
+      })
+    ).toEqual({
+      ...initialState,
+      microphone: '1234'
+    });
+  });
+
+  it('it handles SET_SPEAKER', () => {
+    expect(
+      reducer(undefined, {
+        type: actions.SET_SPEAKER,
+        deviceId: '1234'
+      })
+    ).toEqual({
+      ...initialState,
+      speaker: '1234'
+    });
+  });
+
+  it('it handles SET_RINGTONE_SPEAKER', () => {
+    expect(
+      reducer(undefined, {
+        type: actions.SET_RINGTONE_SPEAKER,
+        deviceId: '1234'
+      })
+    ).toEqual({
+      ...initialState,
+      speakerRingtone: '1234'
+    });
+  });
+});

--- a/src/settings/utils/devices.js
+++ b/src/settings/utils/devices.js
@@ -68,7 +68,7 @@ function gotStream(stream) {
 }
 
 /**
- * This function will set the audio output of the application to the
+ * This function will set the audio of the ringtones to the
  * selected device.
  * @param sinkId The id of the device that will be set.
  */
@@ -79,53 +79,25 @@ export function changeRingToneDestination(sinkId) {
    * @type {string[]}
    */
   let audioIds = ['ringbackTone', 'ringTone'];
-  let elements = audioIds.map(value => document.getElementById(value));
-
-  elements.forEach(element => {
-    if (!element) {
-      warnMessage('Audio element does not exist.');
-      return;
-    }
-    logMessage('sinkId:', sinkId);
-
-    if (typeof element.sinkId !== 'undefined') {
-      element
-        .setSinkId(sinkId)
-        .then(function() {
-          logMessage('Success, audio output device attached: ' + sinkId);
-        })
-        .catch(function(error) {
-          let message = error;
-          if (error.name === 'SecurityError') {
-            message =
-              'You need to use HTTPS for selecting audio output ' +
-              'device: ' +
-              error;
-          }
-          errorMessage(message);
-          // Jump back to first output device in the list as it's the default.
-          // audioOutputSelect.selectedIndex = 0
-        });
-    } else {
-      warnMessage(
-        'Browser does not support output device selection. If using Chrome, it needs an audio or video element'
-      );
-    }
-  });
+  changeAudioDestination(sinkId, audioIds);
 }
 
 /**
- * This function will set the audio output of the application to the
+ * This function will set the audio of the input call to the
  * selected device.
  * @param sinkId The id of the device that will be set.
  */
-export function changeAudioDestination(sinkId) {
+export function changeAudioInputDestination(sinkId) {
   /**
    * We need to loop through all the different application's audio inputs
    * in order to configure their sound.
    * @type {string[]}
    */
   let audioIds = ['callsAudioInput'];
+  changeAudioDestination(sinkId, audioIds);
+}
+
+function changeAudioDestination(sinkId, audioIds) {
   let elements = audioIds.map(value => document.getElementById(value));
 
   elements.forEach(element => {

--- a/src/settings/utils/devices.js
+++ b/src/settings/utils/devices.js
@@ -1,4 +1,4 @@
-import { errorMessage, logMessage, warnMessage } from "common/utils/logs";
+import { errorMessage, logMessage, warnMessage } from 'common/utils/logs';
 /**
  * Generates the constraints that will be passed to getUserMedia WebRTC method
  * @param sourceId Identifier of the device that will be set
@@ -16,15 +16,15 @@ function gotDevices(deviceInfos) {
   // Handles being called several times to update labels. Preserve values.
   return deviceInfos.map((device, index) => {
     const value = device.deviceId;
-    if (device.kind === "audioinput") {
+    if (device.kind === 'audioinput') {
       const text = device.label || `microphone${index}`;
-      return { value: value, text: text, kind: "audioinput" };
-    } else if (device.kind === "audiooutput") {
+      return { value: value, text: text, kind: 'audioinput' };
+    } else if (device.kind === 'audiooutput') {
       const text = device.label || `speaker${index}`;
-      return { value: value, text: text, kind: "audiooutput" };
+      return { value: value, text: text, kind: 'audiooutput' };
     } else {
       const text = device.label || `other${index}`;
-      return { value: value, text: text, kind: "other" };
+      return { value: value, text: text, kind: 'other' };
     }
   });
 }
@@ -45,7 +45,7 @@ export function changeInputDevice(inputSourceId = null) {
 }
 
 function handleError(error) {
-  errorMessage("navigator.getUserMedia error: ", error);
+  errorMessage('navigator.getUserMedia error: ', error);
 }
 
 export function stopStreams() {
@@ -57,8 +57,8 @@ export function stopStreams() {
 }
 
 function gotStream(stream) {
-  logMessage("Got stream ", stream);
-  let audio = document.querySelector("audio");
+  logMessage('Got stream ', stream);
+  let audio = document.querySelector('audio');
   window.stream = stream; // make stream available to console
   if (audio) {
     audio.srcObject = stream;
@@ -72,34 +72,34 @@ function gotStream(stream) {
  * selected device.
  * @param sinkId The id of the device that will be set.
  */
-export function changeAudioDestination(sinkId) {
+export function changeRingToneDestination(sinkId) {
   /**
    * We need to loop through all the different application's audio inputs
    * in order to configure their sound.
    * @type {string[]}
    */
-  let audioIds = ["ringbackTone", "callsAudioInput", "ringTone"];
+  let audioIds = ['ringbackTone', 'ringTone'];
   let elements = audioIds.map(value => document.getElementById(value));
 
   elements.forEach(element => {
     if (!element) {
-      warnMessage("Audio element does not exist.");
+      warnMessage('Audio element does not exist.');
       return;
     }
-    logMessage("sinkId:", sinkId);
+    logMessage('sinkId:', sinkId);
 
-    if (typeof element.sinkId !== "undefined") {
+    if (typeof element.sinkId !== 'undefined') {
       element
         .setSinkId(sinkId)
         .then(function() {
-          logMessage("Success, audio output device attached: " + sinkId);
+          logMessage('Success, audio output device attached: ' + sinkId);
         })
         .catch(function(error) {
           let message = error;
-          if (error.name === "SecurityError") {
+          if (error.name === 'SecurityError') {
             message =
-              "You need to use HTTPS for selecting audio output " +
-              "device: " +
+              'You need to use HTTPS for selecting audio output ' +
+              'device: ' +
               error;
           }
           errorMessage(message);
@@ -108,7 +108,54 @@ export function changeAudioDestination(sinkId) {
         });
     } else {
       warnMessage(
-        "Browser does not support output device selection. If using Chrome, it needs an audio or video element"
+        'Browser does not support output device selection. If using Chrome, it needs an audio or video element'
+      );
+    }
+  });
+}
+
+/**
+ * This function will set the audio output of the application to the
+ * selected device.
+ * @param sinkId The id of the device that will be set.
+ */
+export function changeAudioDestination(sinkId) {
+  /**
+   * We need to loop through all the different application's audio inputs
+   * in order to configure their sound.
+   * @type {string[]}
+   */
+  let audioIds = ['callsAudioInput'];
+  let elements = audioIds.map(value => document.getElementById(value));
+
+  elements.forEach(element => {
+    if (!element) {
+      warnMessage('Audio element does not exist.');
+      return;
+    }
+    logMessage('sinkId:', sinkId);
+
+    if (typeof element.sinkId !== 'undefined') {
+      element
+        .setSinkId(sinkId)
+        .then(function() {
+          logMessage('Success, audio output device attached: ' + sinkId);
+        })
+        .catch(function(error) {
+          let message = error;
+          if (error.name === 'SecurityError') {
+            message =
+              'You need to use HTTPS for selecting audio output ' +
+              'device: ' +
+              error;
+          }
+          errorMessage(message);
+          // Jump back to first output device in the list as it's the default.
+          // audioOutputSelect.selectedIndex = 0
+        });
+    } else {
+      warnMessage(
+        'Browser does not support output device selection. If using Chrome, it needs an audio or video element'
       );
     }
   });


### PR DESCRIPTION
#110 

I add a new selector at the settings menu for select the output device only for the ringtones. I make this changes creating a new method in devices.js and separating the output with another method called changeRingToneDestination thats is similar than.