### PR TITLE
Add notarize and code signing in Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Dial is a webapp built using React whose purpose is making and receive calls amo
 ## Development
 
 - [Requirements](#requirements)
+- [Read the docs](#read-the-docs)
 - [Install dependencies](#install-dependencies)
 - [Creating the .env configuration files](#creating-the-env-configuration-files)
 - [Setting up the mock server](#setting-up-the-mock-server)
@@ -29,8 +30,13 @@ Dial is a webapp built using React whose purpose is making and receive calls amo
 
 ### Requirements
 
-- node v11.10
-- yarn 1.16.0
+- node >= v11.10
+- yarn >= 1.17.3
+
+### 0. Read the docs
+
+- [Contributing Guidelines](docs/CONTRIBUTING.md)
+- [Git Basics](docs/git-basics.md)
 
 ### 1. Install dependencies
 
@@ -52,12 +58,14 @@ This file includes several enviroments that must be set:
 
 ## Setting up the mock server
 
+    ⚠️ TODO: Update the responses from the server
+
 The mock server simulates the behaviour of a backend server by providing some sample responses.
 
 Then run the server:
 
 ```bash
-npm run mock-server
+yarn run mock-server
 ```
 
 More info about this server: https://github.com/smollweide/node-mock-server#readme
@@ -74,6 +82,8 @@ More info about this server: https://github.com/smollweide/node-mock-server#read
 
 ## Adding your own API Client
 
+    ⚠️ TODO: Update this section
+
 This application uses an API to connect to the telephony backend (Called TONE) but it can be
 customize with your own library. To add it, you can use the `src/third-party` folder and
 then reference it using the environment variable `REACT_APP_TONE_API_PATH` to set
@@ -83,7 +93,7 @@ a path to the file.
 
 * `yarn electron-start`: Runs the application on development mode.
 
-## Run the application in debug mode using Visual Studio Code
+### Run the application in debug mode using Visual Studio Code
 
 The project configuration is defined in the .vscode folder. In this folder we have configured the Visual Studio Code debugger with a launch.json file. To run it in debug mode just go to the "bug" icon in the Visual Studio code and click on the start server.
 
@@ -91,17 +101,37 @@ The project configuration is defined in the .vscode folder. In this folder we ha
 
 Application can be tested in two different ways:
 
-* Using [Jest](https://jestjs.io/) for unit tests.
+* Using [Jest](https://jestjs.io/) to run the tests.
+* Using [React Testing Library](https://testing-library.com/docs/react-testing-library/intro) for the unit testing.
 
 ### Unit tests
 
-Tests are located on `src/__tests__` folder.
+Tests are located in each component folder.
 
-In order to run them: `yarn test`
+In order to run them:
+
+```bash
+yarn test
+```
+
+#### Coverage testing
+
+To test the modified files:
+
+```bash
+yarn test --coverage
+```
+
+To test all the files:
+
+```bash
+yarn test --coverage --watchAll
+```
 
 ## Continuous Integration
 
--TODO-
+- The code is tested on every push and PR
+- Code coverage using [CodeCov](https://codecov.io/) is also triggered and if the coverage decreases, the CI will fail.
 
 ## Packaging and Deployment
 
@@ -119,6 +149,14 @@ Create a `electorn-builder.env` file with the following values:
 - `GH_TOKEN`: This token is required to deploy the application on Github. It can be generated here: https://github.com/settings/tokens/new and the scope must be repository.
 - `WIN_CSC_LINK`: Path to the `.p12` code signing certificate.
 - `WIN_CSC_KEY_PASSWORD`: Password for the `WIN_CSC_LINK` certificate.
+
+Create a `.env` file with the following values:
+
+- `APPLEID`: Apple ID email used in the Apple developer portal.
+- `APPLEIDPASS`: Apple ID password.
+
+These two values are used for notarizing the application:
+    - More info in [this Blog](https://kilianvalkhof.com/2019/electron/notarizing-your-electron-application/) and in [the Apple Docs](https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution)
 
 #### Commands
 
@@ -138,9 +176,9 @@ The following versions will be distributed to users depending on the channel def
 
 Imagine that your application is stable and in version `1.0.1`.
 
-If you want to release a beta for the new `1.1.0` version, you only need to update the package.json version with `1.1.0-beta`.
+If you want to release a beta for the new `1.1.0` version, you only need to publish a prerelease.
 
-When your application is stable enough, you want to release it to all users. For that, you only need to remove the -beta label from the package.json version tag.
+When your application is stable enough, you want to release it to all users. For that, you only need to publish it as release.
 
 #### How to clean all the build releases
 
@@ -149,7 +187,7 @@ Run the following command on `webapp` folder (this one).
 xattr -cr .
 ```
 
-### Steps to generate the right AppImage
+### Steps to generate the propper AppImage
 
 We had some difficulties when we tried to install our AppImage in `Centos 7`.
 
@@ -173,8 +211,6 @@ You will see some logs during the packaging step related to this part.
 
 Every steps related to this part are in `docker/`.
 
-## Docs
+## Other Docs
 
-- [Contributing Guidelines](docs/CONTRIBUTING.md)
-- [Git Basics](docs/git-basics.md)
 - [Create React App Docs (Local)](docs/react.md)

--- a/docker/configure_appimage.js
+++ b/docker/configure_appimage.js
@@ -1,9 +1,16 @@
-const system = require("system-commands");
+const system = require('system-commands');
 
 exports.default = async function(context) {
-  console.log("Adding --no-sandox to AppImage");
-  system("docker build docker/");
-  system("docker run -v $(pwd)/dist/:/root/home/ --privileged $(docker images -a | awk '{ print $3}' | awk 'NR==2')");
-  console.log("Done.");
+  const { electronPlatformName } = context;
+  if (electronPlatformName !== 'linux') {
+    return;
+  }
+
+  console.log('Adding --no-sandox to AppImage');
+  system('docker build docker/');
+  system(
+    "docker run -v $(pwd)/dist/:/root/home/ --privileged $(docker images -a | awk '{ print $3}' | awk 'NR==2')"
+  );
+  console.log('Done.');
   return [];
-}
+};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "preelectron-pack": "yarn build",
     "electron-pack": "yarn build && electron-builder build -mlw",
     "electron-pack-windows": "yarn build && electron-builder build -m",
-    "electron-pack-mac": "yarn build && electron-builder build -m",
+    "electron-pack-mac": "electron-builder build -m",
     "electron-pack-linux": "yarn build && electron-builder build -l",
     "publish-prod": "yarn build && electron-builder build -mlw --publish always",
     "electron-pack-next": "REACT_APP_NEXT=true yarn build && REACT_APP_NEXT=true electron-builder --config electron-builder-next.json build -mlw",
@@ -128,9 +128,11 @@
     "concurrently": "^4.1.1",
     "cross-env": "^5.1.5",
     "devtron": "^1.4.0",
+    "dotenv": "^8.2.0",
     "electron": "^5.0.6",
     "electron-builder": "^21.2.0",
     "electron-devtools-installer": "^2.2.4",
+    "electron-notarize": "^0.1.1",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^3.1.0",
     "eslint-plugin-babel": "^4.1.2",
@@ -165,10 +167,14 @@
       "repo": "desktop-phone-app",
       "publishAutoUpdate": true
     },
+    "afterSign": "scripts/notarize.js",
     "mac": {
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
       "category": "public.app-category.social-networking",
-      "target": "zip",
+      "target": "dmg",
       "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
       "extendInfo": {
         "NSMicrophoneUsageDescription": "This app requires microphone access to record audio."
       }

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -1,0 +1,40 @@
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const { notarize } = require('electron-notarize');
+
+module.exports = async function(params) {
+  // Only notarize the app on Mac OS only.
+  if (process.platform !== 'darwin') {
+    return;
+  }
+  console.log('afterSign hook triggered', params);
+
+  // Same appId in electron-builder.
+  const appId = 'ch.cern.phonewebapp';
+
+  const appPath = path.join(
+    params.appOutDir,
+    `${params.packager.appInfo.productFilename}.app`
+  );
+  if (!fs.existsSync(appPath)) {
+    throw new Error(`Cannot find application at: ${appPath}`);
+  }
+
+  console.log(`Notarizing ${appId} found at ${appPath}`);
+
+  console.log(`Apple ID used: ${process.env.APPLEID}`);
+
+  try {
+    await notarize({
+      appBundleId: appId,
+      appPath,
+      appleId: process.env.APPLEID,
+      appleIdPassword: process.env.APPLEIDPASS
+    });
+  } catch (error) {
+    console.error(error);
+  }
+
+  console.log(`Done notarizing ${appId}`);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2307,7 +2307,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.2.3:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
@@ -3094,6 +3094,11 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
+
+compare-version@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080"
+  integrity sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA=
 
 component-emitter@^1.2.1:
   version "1.3.0"
@@ -4075,7 +4080,7 @@ dotenv@6.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
 
-dotenv@^8.0.0:
+dotenv@^8.0.0, dotenv@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
@@ -4183,6 +4188,26 @@ electron-log@^3.0.6:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-3.0.8.tgz#ea672dc40b560143ed5d887eff1ff1904fe9ef71"
   integrity sha512-B9+eJ8z3UbDnWEz+G33SIJvEDeKLznHEV4sCu6bR31KuOdp3dYN046QBWbLNsvKU+lzFI6eOi+xNCpNHZvatiw==
+
+electron-notarize@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/electron-notarize/-/electron-notarize-0.1.1.tgz#c3563d70c5e7b3315f44e8495b30050a8c408b91"
+  integrity sha512-TpKfJcz4LXl5jiGvZTs5fbEx+wUFXV5u8voeG5WCHWfY/cdgdD8lDZIZRqLVOtR3VO+drgJ9aiSHIO9TYn/fKg==
+  dependencies:
+    debug "^4.1.1"
+    fs-extra "^8.0.1"
+
+electron-osx-sign@^0.4.14:
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.4.14.tgz#770397c0eb604adfe8a3ec044795db3c123e59d3"
+  integrity sha512-72vtrz9I3dOeFDaNvO5thwIjrimDiXMmYEbN0hEBqnvcSSMOWugjim2wiY9ox3dhuBFUhxp3owmuZCoH3Ij08A==
+  dependencies:
+    bluebird "^3.5.0"
+    compare-version "^0.1.2"
+    debug "^2.6.8"
+    isbinaryfile "^3.0.2"
+    minimist "^1.2.0"
+    plist "^3.0.1"
 
 electron-publish@21.2.0:
   version "21.2.0"
@@ -5217,7 +5242,7 @@ fs-extra@^4.0.1, fs-extra@^4.0.2:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^8.1.0:
+fs-extra@^8.0.1, fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
@@ -6510,6 +6535,13 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
+isbinaryfile@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-3.0.3.tgz#5d6def3edebf6e8ca8cae9c30183a804b5f8be80"
+  integrity sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==
+  dependencies:
+    buffer-alloc "^1.2.0"
 
 isbinaryfile@^4.0.2:
   version "4.0.2"
@@ -9018,6 +9050,15 @@ please-upgrade-node@^3.1.1, please-upgrade-node@^3.2.0:
   integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
   dependencies:
     semver-compare "^1.0.0"
+
+plist@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.1.tgz#a9b931d17c304e8912ef0ba3bdd6182baf2e1f8c"
+  integrity sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==
+  dependencies:
+    base64-js "^1.2.3"
+    xmlbuilder "^9.0.7"
+    xmldom "0.1.x"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -11737,6 +11778,11 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+system-commands@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/system-commands/-/system-commands-1.1.7.tgz#f100c0d7da5d489d065b43625fc9fef1c38b38f2"
+  integrity sha512-PfswB3P+qrSZcm7nIOJzKMe0qMp7wGVM7B+UYBkaduS6z2n+iM2sk4kw3G4+zY1aRI32+ZgKTUUAlhc3YSneJA==
+
 table@^5.2.3:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
@@ -12908,10 +12954,20 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
+xmlbuilder@^9.0.7:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+
 xmlchars@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xmldom@0.1.x:
+  version "0.1.27"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
+  integrity sha1-1QH5ezvbQDr4757MIFcxh6rawOk=
 
 xregexp@4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This should allow the application to work in Mac OS Catalina. The app is now sent to Apple’s notary service every time is packaged.

- Some docs have been added.
- Beware of the `.env` file section in the docs
- Added as well the script to notarize

This also references this issue #149