### PR TITLE
🛑 WIP: Change remove contact to use the username

### DIFF
--- a/src/calls/components/contacts/ContactAddButton/ContactAddButton.js
+++ b/src/calls/components/contacts/ContactAddButton/ContactAddButton.js
@@ -45,6 +45,7 @@ function ContactAddButton({ contact }) {
   if (hasContact) {
     return (
       <Icon
+        data-testid="HasContactIcon"
         name="star"
         className={styles.ContactAddButton}
         size="big"
@@ -56,6 +57,7 @@ function ContactAddButton({ contact }) {
 
   return (
     <Icon
+      data-testid="HasNoContactIcon"
       name="star"
       className={styles.ContactAddButton}
       size="big"

--- a/src/calls/components/contacts/ContactAddButton/ContactAddButton.js
+++ b/src/calls/components/contacts/ContactAddButton/ContactAddButton.js
@@ -20,7 +20,7 @@ function ContactAddButton({ contact }) {
     setHasContact(true);
   };
   const removeContact = async () => {
-    await dispatch(dialBackendApi().removeUserContact(contact.personId));
+    await dispatch(dialBackendApi().removeUserContact(contact.username));
     setHasContact(false);
   };
 
@@ -28,11 +28,9 @@ function ContactAddButton({ contact }) {
     const ids =
       contacts === undefined || contacts.contacts === undefined
         ? []
-        : contacts.contacts.map(a => a.personId.toString());
-    if (
-      ids.includes(contact.personId) ||
-      ids.includes(contact.personId.toString())
-    ) {
+        : contacts.contacts.map(a => a.username);
+
+    if (ids.includes(contact.username) || ids.includes(contact.username)) {
       setHasContact(true);
     } else {
       setHasContact(false);

--- a/src/calls/components/contacts/ContactAddButton/ContactAddButton.test.js
+++ b/src/calls/components/contacts/ContactAddButton/ContactAddButton.test.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, waitForElement } from '@testing-library/react';
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+
+import { createHashHistory } from 'history';
+import { routerMiddleware } from 'connected-react-router';
+import ContactAddButton from './ContactAddButton';
+
+const history = createHashHistory();
+const middlewares = [thunk, routerMiddleware(history)];
+const mockStore = configureMockStore(middlewares);
+
+describe('ContactAddButton tests', () => {
+  let store;
+  let initialState;
+
+  beforeEach(() => {
+    initialState = {
+      contacts: {
+        getContacts: {
+          contacts: []
+        },
+        addContacts: {
+          added: false
+        },
+        removeContacts: {
+          removed: false
+        }
+      }
+    };
+    store = mockStore(initialState);
+    store.dispatch = jest.fn();
+  });
+
+  it('renders the component with not added contact', async () => {
+    const contact = {
+      personId: '222333'
+    };
+    const { asFragment, queryByTestId, getByTestId } = render(
+      <Provider store={store}>
+        <ContactAddButton contact={contact} />
+      </Provider>
+    );
+    await waitForElement(() => getByTestId('HasNoContactIcon'));
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders the component with added contact', async () => {
+    const contact = {
+      personId: '222333',
+      username: 'lesknope'
+    };
+    initialState.contacts.getContacts.contacts.contacts = [contact];
+    const { asFragment, queryByTestId, getByTestId } = render(
+      <Provider store={store}>
+        <ContactAddButton contact={contact} />
+      </Provider>
+    );
+    await waitForElement(() => getByTestId('HasContactIcon'));
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/calls/components/contacts/ContactAddButton/__snapshots__/ContactAddButton.test.js.snap
+++ b/src/calls/components/contacts/ContactAddButton/__snapshots__/ContactAddButton.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContactAddButton tests renders the component with added contact 1`] = `
+<DocumentFragment>
+  <i
+    aria-hidden="true"
+    class="yellow star big icon ContactAddButton"
+    data-testid="HasContactIcon"
+  />
+</DocumentFragment>
+`;
+
+exports[`ContactAddButton tests renders the component with not added contact 1`] = `
+<DocumentFragment>
+  <i
+    aria-hidden="true"
+    class="grey star big icon ContactAddButton"
+    data-testid="HasNoContactIcon"
+  />
+</DocumentFragment>
+`;


### PR DESCRIPTION
**⚠️ Need to update the backend before merging this ⚠️**

To remove a contact, now the `username` is used instead of the `personId`.

- A change in the core was also needed.
- A change in the backend, that now returns the `username` as well.