### PR TITLE
Fix: Connect to the only number automatically

### DIFF
--- a/src/calls/components/NumberConnector/NumberConnector.js
+++ b/src/calls/components/NumberConnector/NumberConnector.js
@@ -104,7 +104,7 @@ function NumberConnector({
 
     getUserPhoneNumbers().then(() => {
       if (numberOfMobileNumbers === 1) {
-        connect(activeNumber);
+        connect(firstNumberAvailable);
       }
     });
   }, [

--- a/src/calls/components/NumberConnector/NumberConnector.js
+++ b/src/calls/components/NumberConnector/NumberConnector.js
@@ -112,7 +112,8 @@ function NumberConnector({
     connect,
     getUserPhoneNumbers,
     numberOfMobileNumbers,
-    rememberNumber
+    rememberNumber,
+    firstNumberAvailable
   ]);
 
   const rememberNumberOnChange = () => {


### PR DESCRIPTION
Before, it was trying to connect to the active number.
if it wasn't available, it was trying to register with undefined.