### PR TITLE
Fix the error adding to the NotConnectedScreen ipcRenderer

### DIFF
--- a/src/calls/screens/CallsScreen/NotConnectedScreen/NotConnectedScreen.js
+++ b/src/calls/screens/CallsScreen/NotConnectedScreen/NotConnectedScreen.js
@@ -12,6 +12,9 @@ import SettingsButtonContainer from 'common/components/SettingsButton/SettingsBu
 import SettingsModalContainer from 'settings/components/SettingsModal/SettingsModalContainer';
 import OnlineConnectionBannerContainer from 'common/components/OnlineStatusBanner/OnlineStatusBannerContainer';
 
+const electron = window.require('electron');
+const { ipcRenderer } = electron;
+
 function SelectPhoneNumberModal() {
   const loginErrorSolutions = [
     'You can try again in few minutes.',
@@ -37,12 +40,16 @@ function SelectPhoneNumberModal() {
   );
 }
 
-function NotConnectedScreen({ isAuthenticated, connected }) {
+function NotConnectedScreen({ isAuthenticated, connected, logout }) {
+  ipcRenderer.on('logoutRequest', () => {
+    logout();
+  });
+
   if (!isAuthenticated) return <Redirect to="/login" />;
   if (connected) return <Redirect to="/home" />;
   return (
     <ErrorBoundary>
-      <OnlineConnectionBannerContainer style={{ position: "fixed" }}/>
+      <OnlineConnectionBannerContainer style={{ position: 'fixed' }} />
       <SettingsModalContainer />
       <SelectPhoneNumberModal />
     </ErrorBoundary>

--- a/src/calls/screens/CallsScreen/NotConnectedScreen/NotConnectedScreenContainer.js
+++ b/src/calls/screens/CallsScreen/NotConnectedScreen/NotConnectedScreenContainer.js
@@ -1,6 +1,8 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import NotConnectedScreen from './NotConnectedScreen';
+import dialBackendApi from 'services/api';
+import { bindActionCreators } from 'redux';
 
 function mapStateToProps({ auth, connection }) {
   return {
@@ -9,8 +11,18 @@ function mapStateToProps({ auth, connection }) {
   };
 }
 
-export const NotConnectedScreenContainer = connect(mapStateToProps)(
-  NotConnectedScreen
-);
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(
+    {
+      logout: dialBackendApi().logout
+    },
+    dispatch
+  );
+}
+
+export const NotConnectedScreenContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(NotConnectedScreen);
 
 export default withRouter(NotConnectedScreenContainer);


### PR DESCRIPTION
#216 

I added to the NotConnectedScreen a capture of the ipcRenderer event logoutRequest. With this addition, now you can logout from the NotConnectedScreen with the menubar.